### PR TITLE
Fix send order to backend on WhatsApp checkout

### DIFF
--- a/frontend/src/pages/Home.js
+++ b/frontend/src/pages/Home.js
@@ -216,7 +216,7 @@ const Home = () => {
     return cart.reduce((total, item) => total + item.quantity, 0);
   };
 
-  const sendWhatsAppOrder = () => {
+  const sendWhatsAppOrder = async () => {
     let message = " *Pedido Corujão Marmitas*\n\n";
 
     message += ` *Cliente:* ${nome || "Não informado"}\n`;
@@ -273,6 +273,8 @@ const Home = () => {
       `https://wa.me/${phoneNumber}?text=${encodedMessage}`,
       "_blank"
     );
+
+    await enviarPedido();
   };
 
   const enviarPedido = async () => {


### PR DESCRIPTION
## Summary
- ensure sending a WhatsApp order also persists it in the backend

## Testing
- `node frontend/node_modules/react-scripts/scripts/test.js --watchAll=false` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_683f5ae6b1108327a0fe2dda8f971164