### PR TITLE
Fix backend local run with credentials

### DIFF
--- a/backEnd/index.js
+++ b/backEnd/index.js
@@ -2,7 +2,14 @@ const express = require("express");
 const cors = require("cors");
 const bodyParser = require("body-parser");
 const { google } = require("googleapis");
-const keys = JSON.parse(process.env.CREDENTIALS_JSON);
+const fs = require("fs");
+
+let keys;
+if (process.env.CREDENTIALS_JSON) {
+  keys = JSON.parse(process.env.CREDENTIALS_JSON);
+} else {
+  keys = JSON.parse(fs.readFileSync("credentials.json", "utf8"));
+}
 
 const app = express();
 
@@ -17,7 +24,6 @@ app.use(cors({
 
 app.options("/enviar-pedido", cors());
 
-app.options("*", cors());
 
 app.use(bodyParser.json());
 


### PR DESCRIPTION
## Summary
- allow backend to read credentials from file when env var isn't set
- remove wildcard `app.options` that caused runtime error

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `node index.js` in `backEnd`

------
https://chatgpt.com/codex/tasks/task_e_68458c783204832784094bfb5017bac1