### PR TITLE
Add size-aware pricing buttons

### DIFF
--- a/src/components/PriceButtons.js
+++ b/src/components/PriceButtons.js
@@ -1,0 +1,38 @@
+import React from "react";
+
+// Renders size buttons based on a price string
+export default function PriceButtons({ price, item, onAdd }) {
+  if (!price) return null;
+  const prices = String(price)
+    .split(',')
+    .map((p) => parseFloat(p.trim()))
+    .filter((p) => !Number.isNaN(p));
+
+  const sizeLabels = ['P', 'M', 'G'];
+
+  if (prices.length <= 1) {
+    const value = prices[0] ?? 0;
+    return (
+      <button
+        onClick={() => onAdd({ ...item, price: value })}
+        className="bg-gradient-to-r bg-[#5d3d29] text-white px-6 py-2 rounded-full"
+      >
+        Adicionar
+      </button>
+    );
+  }
+
+  return (
+    <div className="flex gap-2">
+      {prices.map((val, idx) => (
+        <button
+          key={idx}
+          onClick={() => onAdd({ ...item, price: val, size: sizeLabels[idx] })}
+          className="bg-gradient-to-r bg-[#5d3d29] text-white px-4 py-2 rounded-full"
+        >
+          {sizeLabels[idx]} - R$ {val.toFixed(2)}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/components/PriceButtons.js
+++ b/src/components/PriceButtons.js
@@ -1,17 +1,44 @@
 import React from "react";
 
-// Renders size buttons based on a price string
-export default function PriceButtons({ price, item, onAdd }) {
-  if (!price) return null;
-  const prices = String(price)
-    .split(',')
-    .map((p) => parseFloat(p.trim()))
-    .filter((p) => !Number.isNaN(p));
+/**
+ * Parse the price field or size properties (Pequeno, Medio, Grande)
+ * and return an array of numeric prices.
+ */
+export function parsePrices(price, item = {}) {
+  let values = [];
 
-  const sizeLabels = ['P', 'M', 'G'];
+  if (price !== undefined && price !== null && price !== "") {
+    if (typeof price === "number") {
+      values = [Number(price)];
+    } else {
+      values = String(price)
+        .split(',')
+        .map((p) => parseFloat(p.trim()))
+        .filter((n) => !Number.isNaN(n));
+    }
+  }
 
-  if (prices.length <= 1) {
-    const value = prices[0] ?? 0;
+  if (!values.length) {
+    const keys = ["Pequeno", "Medio", "Grande"];
+    values = keys
+      .map((k) => item[k])
+      .filter((v) => v !== undefined && v !== null)
+      .map((v) => parseFloat(v))
+      .filter((n) => !Number.isNaN(n));
+  }
+
+  return values;
+}
+
+// Renders size buttons based on available prices
+export default function PriceButtons({ price, item = {}, onAdd = () => {} }) {
+  const prices = parsePrices(price, item);
+  const sizeLabels = ["P", "M", "G"];
+
+  if (!prices.length) return null;
+
+  if (prices.length === 1) {
+    const value = prices[0];
     return (
       <button
         onClick={() => onAdd({ ...item, price: value })}
@@ -27,7 +54,9 @@ export default function PriceButtons({ price, item, onAdd }) {
       {prices.map((val, idx) => (
         <button
           key={idx}
-          onClick={() => onAdd({ ...item, price: val, size: sizeLabels[idx] })}
+          onClick={() =>
+            onAdd({ ...item, price: val, size: sizeLabels[idx] })
+          }
           className="bg-gradient-to-r bg-[#5d3d29] text-white px-4 py-2 rounded-full"
         >
           {sizeLabels[idx]} - R$ {val.toFixed(2)}

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -15,7 +15,7 @@ import { toast, ToastContainer } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
 import Cardapio1 from "../components/Cardapio1";
 import Cardapio2 from "../components/Cardapio2";
-import PriceButtons from "../components/PriceButtons";
+import PriceButtons, { parsePrices } from "../components/PriceButtons";
 
 const Home = () => {
   const navigate = useNavigate();
@@ -389,11 +389,9 @@ const Home = () => {
               <span>⏰ {m.time}</span>
               <span className="text-2xl font-bold text-orange-600">
                 {(() => {
-                  const p = String(m.price)
-                    .split(',')
-                    .map((x) => parseFloat(x.trim()))
-                    .filter((x) => !Number.isNaN(x));
-                  return `R$ ${p[0]?.toFixed(2)}` + (p.length > 1 ? '+' : '');
+                  const p = parsePrices(m.price, m);
+                  if (p.length === 0) return "R$ 0.00";
+                  return `R$ ${p[0].toFixed(2)}` + (p.length > 1 ? "+" : "");
                 })()}
               </span>
             </div>

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -15,6 +15,7 @@ import { toast, ToastContainer } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
 import Cardapio1 from "../components/Cardapio1";
 import Cardapio2 from "../components/Cardapio2";
+import PriceButtons from "../components/PriceButtons";
 
 const Home = () => {
   const navigate = useNavigate();
@@ -387,15 +388,16 @@ const Home = () => {
             <div className="flex justify-between items-center mb-4">
               <span>⏰ {m.time}</span>
               <span className="text-2xl font-bold text-orange-600">
-                R$ {Number(m.price).toFixed(2)}
+                {(() => {
+                  const p = String(m.price)
+                    .split(',')
+                    .map((x) => parseFloat(x.trim()))
+                    .filter((x) => !Number.isNaN(x));
+                  return `R$ ${p[0]?.toFixed(2)}` + (p.length > 1 ? '+' : '');
+                })()}
               </span>
             </div>
-            <button
-              onClick={() => addToCart(m)}
-              className="bg-gradient-to-r bg-[#5d3d29] text-white px-6 py-2 rounded-full"
-            >
-              Adicionar
-            </button>
+            <PriceButtons price={m.price} item={m} onAdd={addToCart} />
           </div>
         ))}
       </div>


### PR DESCRIPTION
## Summary
- parse price strings and render size buttons
- show the first price in the menu with a '+' when there are more options

## Testing
- `npm test --silent -- -w 1` *(fails: Cannot find module 'react-router-dom' from 'src/App.js')*


------
https://chatgpt.com/codex/tasks/task_e_684b4b7754a0832797c9fdf34e0de761