### PR TITLE
Add table management and kitchen dashboard

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -2,6 +2,8 @@ import { Routes, Route } from "react-router-dom";
 import Home from "./pages/Home";
 import ControlePedidos from "./pages/ControlePedidos";
 import Dashboard from "./pages/Dashboard";
+import Table from "./pages/Table";
+import KitchenDashboard from "./dashboard/KitchenDashboard";
 
 function App() {
   return (
@@ -9,6 +11,8 @@ function App() {
       <Route path="/" element={<Home />} />
       <Route path="/controle-pedidos" element={<ControlePedidos />} />
       <Route path="/dashboard" element={<Dashboard />} />
+      <Route path="/mesa" element={<Table />} />
+      <Route path="/cozinha" element={<KitchenDashboard />} />
     </Routes>
   );
 }

--- a/src/dashboard/KitchenDashboard.js
+++ b/src/dashboard/KitchenDashboard.js
@@ -15,13 +15,12 @@ export default function KitchenDashboard() {
     return () => window.removeEventListener("storage", handler);
   }, []);
 
-  const closeOrder = (index) => {
-    const updated = [...orders];
-    const [removed] = updated.splice(index, 1);
+  const closeTable = (mesa) => {
+    const updated = orders.filter((o) => o.mesa !== mesa);
     setOrders(updated);
     localStorage.setItem("dashboard_orders", JSON.stringify(updated));
     const occ = JSON.parse(localStorage.getItem("occupied_tables") || "[]");
-    const idx = occ.indexOf(removed.mesa);
+    const idx = occ.indexOf(mesa);
     if (idx >= 0) {
       occ.splice(idx, 1);
       localStorage.setItem("occupied_tables", JSON.stringify(occ));
@@ -32,19 +31,25 @@ export default function KitchenDashboard() {
     <div className="min-h-screen bg-[#fff4e4] p-4">
       <h2 className="text-2xl font-bold mb-4">Cozinha - Novos Pedidos</h2>
       {orders.length === 0 && <p>Nenhum pedido.</p>}
-      {orders.map((order, idx) => (
-        <div key={idx} className="bg-white p-4 rounded shadow mb-4">
-          <div className="font-semibold">
-            Mesa {order.mesa} - {new Date(order.hora).toLocaleTimeString()}
-          </div>
-          <div className="text-sm mb-2">{order.itens}</div>
-          <div className="mb-2">Total R$ {order.total}</div>
-          <div className="font-bold mb-2">Status: {order.status}</div>
+      {Object.entries(
+        orders.reduce((acc, o) => {
+          acc[o.mesa] = acc[o.mesa] ? [...acc[o.mesa], o] : [o];
+          return acc;
+        }, {})
+      ).map(([mesa, list]) => (
+        <div key={mesa} className="bg-white p-4 rounded shadow mb-4">
+          <div className="font-semibold mb-2">Mesa {mesa}</div>
+          {list.map((order, idx) => (
+            <div key={idx} className="text-sm mb-1">
+              {new Date(order.hora).toLocaleTimeString()} - {order.itens} (R$
+              {order.total})
+            </div>
+          ))}
           <button
-            onClick={() => closeOrder(idx)}
-            className="bg-[#5d3d29] text-white px-3 py-1 rounded"
+            onClick={() => closeTable(mesa)}
+            className="mt-2 bg-[#5d3d29] text-white px-3 py-1 rounded"
           >
-            Fechar Pedido
+            Fechar Mesa
           </button>
         </div>
       ))}

--- a/src/dashboard/KitchenDashboard.js
+++ b/src/dashboard/KitchenDashboard.js
@@ -1,0 +1,53 @@
+import React, { useEffect, useState } from "react";
+
+export default function KitchenDashboard() {
+  const [orders, setOrders] = useState([]);
+
+  const load = () => {
+    const stored = JSON.parse(localStorage.getItem("dashboard_orders") || "[]");
+    setOrders(stored);
+  };
+
+  useEffect(() => {
+    load();
+    const handler = () => load();
+    window.addEventListener("storage", handler);
+    return () => window.removeEventListener("storage", handler);
+  }, []);
+
+  const closeOrder = (index) => {
+    const updated = [...orders];
+    const [removed] = updated.splice(index, 1);
+    setOrders(updated);
+    localStorage.setItem("dashboard_orders", JSON.stringify(updated));
+    const occ = JSON.parse(localStorage.getItem("occupied_tables") || "[]");
+    const idx = occ.indexOf(removed.mesa);
+    if (idx >= 0) {
+      occ.splice(idx, 1);
+      localStorage.setItem("occupied_tables", JSON.stringify(occ));
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-[#fff4e4] p-4">
+      <h2 className="text-2xl font-bold mb-4">Cozinha - Novos Pedidos</h2>
+      {orders.length === 0 && <p>Nenhum pedido.</p>}
+      {orders.map((order, idx) => (
+        <div key={idx} className="bg-white p-4 rounded shadow mb-4">
+          <div className="font-semibold">
+            Mesa {order.mesa} - {new Date(order.hora).toLocaleTimeString()}
+          </div>
+          <div className="text-sm mb-2">{order.itens}</div>
+          <div className="mb-2">Total R$ {order.total}</div>
+          <div className="font-bold mb-2">Status: {order.status}</div>
+          <button
+            onClick={() => closeOrder(idx)}
+            className="bg-[#5d3d29] text-white px-3 py-1 rounded"
+          >
+            Fechar Pedido
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/pages/Dashboard.js
+++ b/src/pages/Dashboard.js
@@ -152,12 +152,26 @@ const Dashboard = () => {
       <header className="bg-[#5d3d29] text-[#fff4e4] py-6">
         <div className="container mx-auto px-4 flex justify-between items-center">
           <h1 className="text-2xl font-bold">Dashboard</h1>
-          <button
-            onClick={() => navigate("/")}
-            className="bg-[#fff4e4] text-[#5d3d29] px-4 py-2 rounded"
-          >
-            Home
-          </button>
+          <div className="space-x-2">
+            <button
+              onClick={() => navigate("/cozinha")}
+              className="bg-[#fff4e4] text-[#5d3d29] px-3 py-1 rounded"
+            >
+              Go to Kitchen View
+            </button>
+            <button
+              onClick={() => navigate("/mesa?mesa=7")}
+              className="bg-[#fff4e4] text-[#5d3d29] px-3 py-1 rounded"
+            >
+              Test Table View
+            </button>
+            <button
+              onClick={() => navigate("/")}
+              className="bg-[#fff4e4] text-[#5d3d29] px-3 py-1 rounded"
+            >
+              Home
+            </button>
+          </div>
         </div>
       </header>
 

--- a/src/pages/Table.js
+++ b/src/pages/Table.js
@@ -5,7 +5,7 @@ import PriceButtons from "../components/PriceButtons";
 
 export default function Table() {
   const [searchParams] = useSearchParams();
-  const mesa = searchParams.get("mesa");
+  const [mesa, setMesa] = useState(null);
   const tableKey = mesa ? `mesa_${mesa}_cart` : null;
 
   const [cardapio1, setCardapio1] = useState([]);
@@ -19,6 +19,18 @@ export default function Table() {
       .then((data) => setCardapio1(data))
       .catch(() => setCardapio1([]));
   }, []);
+
+  // Persist mesa parameter to handle page reloads without query string
+  useEffect(() => {
+    const paramMesa = searchParams.get("mesa");
+    if (paramMesa) {
+      localStorage.setItem("mesa_atual", paramMesa);
+      setMesa(paramMesa);
+    } else {
+      const stored = localStorage.getItem("mesa_atual");
+      if (stored) setMesa(stored);
+    }
+  }, [searchParams]);
 
   useEffect(() => {
     if (!tableKey) return;
@@ -92,6 +104,10 @@ export default function Table() {
       alert("Erro ao enviar pedido");
     }
   };
+
+  if (mesa === null) {
+    return <div className="p-4">Carregando...</div>;
+  }
 
   if (!mesa) {
     return <div className="p-4">Mesa não informada.</div>;

--- a/src/pages/Table.js
+++ b/src/pages/Table.js
@@ -1,0 +1,143 @@
+import React, { useEffect, useState } from "react";
+import { useSearchParams } from "react-router-dom";
+import Cardapio1 from "../components/Cardapio1";
+import PriceButtons from "../components/PriceButtons";
+
+export default function Table() {
+  const [searchParams] = useSearchParams();
+  const mesa = searchParams.get("mesa");
+  const tableKey = mesa ? `mesa_${mesa}_cart` : null;
+
+  const [cardapio1, setCardapio1] = useState([]);
+  const [cart, setCart] = useState([]);
+
+  useEffect(() => {
+    const url =
+      "https://script.google.com/macros/s/AKfycbyYDPV06sKgZMVDEnGlih52_SNiLtQaXocYBzF37fu3rvZmdO5SVzLIo3Az9HotBE4N/exec";
+    fetch(url)
+      .then((res) => res.json())
+      .then((data) => setCardapio1(data))
+      .catch(() => setCardapio1([]));
+  }, []);
+
+  useEffect(() => {
+    if (!tableKey) return;
+    const saved = localStorage.getItem(tableKey);
+    if (saved) setCart(JSON.parse(saved));
+  }, [tableKey]);
+
+  useEffect(() => {
+    if (tableKey) {
+      localStorage.setItem(tableKey, JSON.stringify(cart));
+    }
+  }, [cart, tableKey]);
+
+  const addToCart = (item) => {
+    const existing = cart.find(
+      (ci) => ci.id === item.id && ci.price === item.price
+    );
+    if (existing) {
+      setCart(
+        cart.map((ci) =>
+          ci === existing ? { ...ci, quantity: ci.quantity + 1 } : ci
+        )
+      );
+    } else {
+      setCart([...cart, { ...item, quantity: 1 }]);
+    }
+  };
+
+  const changeQty = (idx, delta) => {
+    setCart((c) =>
+      c.map((item, i) =>
+        i === idx ? { ...item, quantity: Math.max(1, item.quantity + delta) } : item
+      )
+    );
+  };
+
+  const removeItem = (idx) => {
+    setCart(cart.filter((_, i) => i !== idx));
+  };
+
+  const getTotal = () =>
+    cart.reduce((t, i) => t + i.price * i.quantity, 0).toFixed(2);
+
+  const fecharConta = async () => {
+    if (!mesa || cart.length === 0) return;
+    const order = {
+      mesa,
+      hora: new Date().toISOString(),
+      itens: cart.map((i) => `${i.name} x${i.quantity}`).join(" | "),
+      total: getTotal(),
+      status: "New Order",
+    };
+    try {
+      await fetch("/api/enviar-pedido", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(order),
+      });
+      alert("Order sent successfully, please wait for service!");
+      const dash = JSON.parse(localStorage.getItem("dashboard_orders") || "[]");
+      dash.push(order);
+      localStorage.setItem("dashboard_orders", JSON.stringify(dash));
+      const occ = JSON.parse(localStorage.getItem("occupied_tables") || "[]");
+      if (!occ.includes(mesa)) {
+        occ.push(mesa);
+        localStorage.setItem("occupied_tables", JSON.stringify(occ));
+      }
+      localStorage.removeItem(tableKey);
+      setCart([]);
+    } catch (e) {
+      alert("Erro ao enviar pedido");
+    }
+  };
+
+  if (!mesa) {
+    return <div className="p-4">Mesa não informada.</div>;
+  }
+
+  return (
+    <div className="min-h-screen bg-[#fff4e4] p-4">
+      <h2 className="text-2xl font-bold mb-4">Mesa {mesa}</h2>
+      <div className="grid md:grid-cols-2 gap-6">
+        {cardapio1.map((m) => (
+          <div key={m.id} className="bg-white rounded shadow p-4">
+            <h3 className="font-semibold mb-2">{m.name}</h3>
+            <p className="text-sm mb-2">{m.description}</p>
+            <PriceButtons price={m.price} item={m} onAdd={addToCart} />
+          </div>
+        ))}
+      </div>
+
+      <div className="mt-8 bg-white p-4 rounded shadow">
+        <h3 className="text-lg font-bold mb-2">Carrinho</h3>
+        {cart.length === 0 && <p>Nenhum item.</p>}
+        {cart.map((item, idx) => (
+          <div key={idx} className="flex justify-between items-center mb-2">
+            <span>
+              {item.name} - R$ {item.price.toFixed(2)}
+            </span>
+            <div className="flex items-center gap-2">
+              <button onClick={() => changeQty(idx, -1)} className="px-2">-</button>
+              <span>{item.quantity}</span>
+              <button onClick={() => changeQty(idx, 1)} className="px-2">+</button>
+              <button onClick={() => removeItem(idx)} className="px-2 text-red-500">x</button>
+            </div>
+          </div>
+        ))}
+        {cart.length > 0 && (
+          <>
+            <div className="font-bold mt-2">Total: R$ {getTotal()}</div>
+            <button
+              onClick={fecharConta}
+              className="mt-4 bg-green-500 text-white px-4 py-2 rounded"
+            >
+              Fechar Conta
+            </button>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- create a new Table page that captures `mesa` query param and keeps cart per-table in localStorage
- send finalized orders to the existing API and push them to a simple kitchen dashboard
- mark tables occupied until the kitchen closes the order
- add KitchenDashboard component and routes for `/mesa` and `/cozinha`

## Testing
- `npm install --silent`
- `npm test --silent -- --watchAll=false` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_684b8760ffa883279390e6683aa70457