### PR TITLE
Update Google Script cleanup request

### DIFF
--- a/api/limpaMesa/index.js
+++ b/api/limpaMesa/index.js
@@ -4,7 +4,8 @@ export default async function handler(req, res) {
   }
 
   try {
-    const payload = req.body;
+    const mesa = String(req.body?.mesa || "").trim();
+    const payload = { mesa };
 
     const url = "https://script.google.com/macros/s/AKfycbxtHy6Vk6CDa3i6HKT6pYpaaVWovvtB8KZt6vdx8um3xLwzTiicHYB2BxdIMhgdt08l/exec";
 

--- a/src/pages/Mesa.js
+++ b/src/pages/Mesa.js
@@ -180,7 +180,7 @@ const Mesa = () => {
       await fetch("/api/limpaMesa", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({mesa:`${mesa}`}),
+        body: JSON.stringify({ mesa: String(mesa).trim() }),
       });
 
       toast.success("Conta encerrada!", { position: "bottom-right", autoClose: 2000 });


### PR DESCRIPTION
## Summary
- ensure only the table number string is forwarded to the new Apps Script
- trim mesa parameter in front-end before calling the API

## Testing
- `npm install`
- `CI=true npm test --silent -- --watchAll=false` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_684c51bec1f48327b240a0c9e4aa08a2