### PR TITLE
Add table occupancy polling

### DIFF
--- a/api/mesas-status.js
+++ b/api/mesas-status.js
@@ -1,0 +1,28 @@
+export default async function handler(req, res) {
+  if (req.method !== "GET") {
+    return res.status(405).json({ error: "Method Not Allowed" });
+  }
+
+  try {
+    // Endpoint that returns occupied tables in the format
+    // { success: true, mesas: [1,6] }
+    const url =
+      "https://script.google.com/macros/s/AKfycbzcncEtTmtS7DrJdfN5dTAaQbNr02ha_Psql6vdlbjOI8gJEM5ioayiKMpRwUxzzHd_/exec";
+
+    const response = await fetch(url);
+    const text = await response.text();
+
+    if (!response.ok) {
+      return res.status(response.status).send(text);
+    }
+
+    const data = JSON.parse(text);
+    // Return only the array of mesas so the frontend receives [1,6]
+    res.status(200).json(data.mesas || data);
+  } catch (error) {
+    console.error("Erro ao obter status das mesas:", error);
+    res
+      .status(500)
+      .json({ error: "Erro interno ao obter mesas", details: error.message });
+  }
+}

--- a/src/dashboard/components/MesasMenu.js
+++ b/src/dashboard/components/MesasMenu.js
@@ -1,18 +1,56 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 
 const tables = Array.from({ length: 15 }, (_, i) => i + 1);
 
 export default function MesasMenu() {
+  const [status, setStatus] = useState({});
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    const fetchStatus = () => {
+      setLoading(true);
+      fetch("/api/mesas-status")
+        .then((res) => {
+          if (!res.ok) throw new Error(`Erro ${res.status}`);
+          return res.json();
+        })
+        .then((data) => {
+          const mesasArray = Array.isArray(data.mesas) ? data.mesas : data;
+          const occupied = new Set(mesasArray.map((d) => String(d).trim()));
+          const map = {};
+          tables.forEach((t) => {
+            map[t] = occupied.has(String(t));
+          });
+          setStatus(map);
+          setError(null);
+        })
+        .catch((err) => {
+          console.error("Falha ao buscar status das mesas:", err);
+          setError("Erro ao buscar mesas");
+        })
+        .finally(() => setLoading(false));
+    };
+
+    fetchStatus();
+    const id = setInterval(fetchStatus, 60_000);
+    return () => clearInterval(id);
+  }, []);
+
   return (
     <aside className="fixed top-0 left-0 h-full w-40 bg-[#5d3d29] text-[#fff4e4] p-4 space-y-2 overflow-y-auto z-40">
       <h2 className="text-lg font-bold mb-4">Tables</h2>
+      {loading && <p className="text-sm">Carregando...</p>}
+      {error && <p className="text-sm text-red-400">{error}</p>}
       {tables.map((t) => (
         <a
           key={t}
           href={`/#/mesa?mesa=${t}`}
           target="_blank"
           rel="noopener noreferrer"
-          className="block bg-[#fff4e4] text-[#5d3d29] rounded px-2 py-1 text-center"
+          className={`block rounded px-2 py-1 text-center ${
+            status[t] ? "bg-yellow-300 text-[#5d3d29]" : "bg-[#fff4e4] text-[#5d3d29]"
+          }`}
         >
           Table {t}
         </a>


### PR DESCRIPTION
## Summary
- poll `Mesas` spreadsheet via new `/api/mesas-status` route
- refresh sidebar list to highlight occupied tables
- return only mesas array from the API and parse it on the client

## Testing
- `npm test --silent` *(fails: Cannot find module 'react-router-dom' from 'src/App.js')*


------
https://chatgpt.com/codex/tasks/task_e_684cfba7f8848327b400a0065d265d5d