### PR TITLE
Add latest orders menu to dashboard

### DIFF
--- a/src/dashboard/components/LatestOrders.js
+++ b/src/dashboard/components/LatestOrders.js
@@ -1,0 +1,45 @@
+import React from "react";
+
+export default function LatestOrders({ orders }) {
+  if (!orders || orders.length === 0) {
+    return (
+      <p className="text-center text-gray-500">Nenhum pedido encontrado.</p>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {orders.map((o) => {
+        const products = String(o["Produto(s)"] || "")
+          .split("|")
+          .map((p) => p.trim())
+          .filter(Boolean);
+        const table = o.Mesa || o["Mesa"] || o["Endereço"] || "-";
+        return (
+          <div key={o.ID} className="bg-white p-4 rounded shadow border">
+            <div className="flex justify-between mb-2">
+              <span className="font-semibold">Mesa {table}</span>
+              <span className="text-sm text-gray-600">
+                {new Date(o.Data).toLocaleString()}
+              </span>
+            </div>
+            <ul className="text-sm mb-2 space-y-1">
+              {products.map((p, i) => (
+                <li key={i}>{p}</li>
+              ))}
+            </ul>
+            <div className="flex justify-between items-center">
+              <span className="font-bold">Total: R$ {parseFloat(o.Total || 0).toFixed(2)}</span>
+              <button
+                onClick={() => window.print()}
+                className="bg-[#5d3d29] text-white px-3 py-1 rounded"
+              >
+                Imprimir Recibo
+              </button>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/pages/Dashboard.js
+++ b/src/pages/Dashboard.js
@@ -2,18 +2,7 @@ import React, { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import LoginPedidos from "../components/LoginPedidos";
 import MesasMenu from "../dashboard/components/MesasMenu";
-import { Bar } from "react-chartjs-2";
-import {
-  Chart,
-  ArcElement,
-  BarElement,
-  CategoryScale,
-  LinearScale,
-  Tooltip,
-  Legend,
-} from "chart.js";
-
-Chart.register(ArcElement, BarElement, CategoryScale, LinearScale, Tooltip, Legend);
+import LatestOrders from "../dashboard/components/LatestOrders";
 
 const API_URL =
   "https://script.google.com/macros/s/AKfycbwHrRUQZIWj8edBBQA-2tBA6J-mIVTypi5w5BFfBULIb5G1vpposGqQ2I3l-b3tjTO_/exec";
@@ -25,10 +14,15 @@ const Dashboard = () => {
   const [filter, setFilter] = useState("today");
 
   useEffect(() => {
-    fetch(API_URL)
-      .then((res) => res.json())
-      .then((data) => setOrders(data))
-      .catch((err) => console.error("Falha ao buscar API", err));
+    const fetchOrders = () => {
+      fetch(API_URL)
+        .then((res) => res.json())
+        .then((data) => setOrders(data))
+        .catch((err) => console.error("Falha ao buscar API", err));
+    };
+    fetchOrders();
+    const id = setInterval(fetchOrders, 60000);
+    return () => clearInterval(id);
   }, []);
 
   useEffect(() => {
@@ -131,19 +125,9 @@ const Dashboard = () => {
     ? `${topProductEntry[0]} (${topProductEntry[1]})`
     : "-";
 
-  const barData = {
-    labels: ["Concluído", "Pendente"],
-    datasets: [
-      {
-        data: [completedCount, pendingCount],
-        backgroundColor: ["#5d3d29", "#facc15"],
-      },
-    ],
-  };
-  const barOptions = {
-    responsive: true,
-    plugins: { legend: { display: false } },
-  };
+  const latestOrders = [...filtered]
+    .sort((a, b) => new Date(b.Data) - new Date(a.Data))
+    .slice(0, 10);
 
   const filterLabel =
     filter === "today" ? "Hoje" : filter === "week" ? "Semana" : "Mês";
@@ -219,7 +203,8 @@ const Dashboard = () => {
             <p>Cliente com mais pedidos: {topCustomer}</p>
           </div>
           <div className="bg-white p-6 rounded shadow">
-            <Bar data={barData} options={barOptions} />
+            <h2 className="font-bold text-[#5d3d29] text-lg mb-4">Últimos Pedidos</h2>
+            <LatestOrders orders={latestOrders} />
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- show latest table orders list in dashboard
- refresh order data every minute
- add print receipt button

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d009a63608327adcb6c8385ad9c29