### PR TITLE
Add checkout alerts for tables

### DIFF
--- a/src/dashboard/components/MesasMenu.js
+++ b/src/dashboard/components/MesasMenu.js
@@ -5,7 +5,7 @@ const MESAS_API =
 
 const tables = Array.from({ length: 15 }, (_, i) => i + 1);
 
-export default function MesasMenu() {
+export default function MesasMenu({ checkoutRequests = [] }) {
   const [mesasOcupadas, setMesasOcupadas] = useState([]);
 
   useEffect(() => {
@@ -35,6 +35,7 @@ export default function MesasMenu() {
       <h2 className="text-lg font-bold mb-4">Mesas</h2>
       {tables.map((t) => {
         const isOccupied = mesasOcupadas.includes(String(t));
+        const isCheckout = checkoutRequests.includes(String(t));
         return (
           <a
             key={t}
@@ -42,7 +43,11 @@ export default function MesasMenu() {
             target="_blank"
             rel="noopener noreferrer"
             className={`block rounded px-2 py-1 text-center ${
-              isOccupied ? "bg-yellow-300 text-[#5d3d29]" : "bg-[#fff4e4] text-[#5d3d29]"
+              isCheckout
+                ? "bg-red-200 border-red-500 border text-[#5d3d29]"
+                : isOccupied
+                ? "bg-yellow-300 text-[#5d3d29]"
+                : "bg-[#fff4e4] text-[#5d3d29]"
             }`}
           >
             Mesa {t}

--- a/src/pages/Dashboard.js
+++ b/src/pages/Dashboard.js
@@ -24,6 +24,13 @@ const Dashboard = () => {
   const [autorizado, setAutorizado] = useState(false);
   const [orders, setOrders] = useState([]);
   const [filter, setFilter] = useState("today");
+  const [checkoutRequests, setCheckoutRequests] = useState(() => {
+    try {
+      return JSON.parse(localStorage.getItem("checkoutRequests") || "[]");
+    } catch {
+      return [];
+    }
+  });
 
   useEffect(() => {
     fetch(API_URL)
@@ -35,6 +42,21 @@ const Dashboard = () => {
   useEffect(() => {
     const autorizadoLocal = localStorage.getItem("autorizado");
     setAutorizado(autorizadoLocal === "true");
+  }, []);
+
+  useEffect(() => {
+    const handler = () => {
+      try {
+        setCheckoutRequests(
+          JSON.parse(localStorage.getItem("checkoutRequests") || "[]"),
+        );
+      } catch {
+        setCheckoutRequests([]);
+      }
+    };
+    handler();
+    window.addEventListener("storage", handler);
+    return () => window.removeEventListener("storage", handler);
   }, []);
 
   if (!autorizado) {
@@ -160,7 +182,19 @@ const Dashboard = () => {
 
   return (
     <div className="min-h-screen bg-[#fff4e4]">
-      <MesasMenu />
+      <MesasMenu checkoutRequests={checkoutRequests} />
+      {checkoutRequests.length > 0 && (
+        <div className="fixed top-0 right-0 m-4 w-60 space-y-2 z-50">
+          {checkoutRequests.map((m) => (
+            <div
+              key={m}
+              className="bg-red-100 border border-red-500 text-red-700 p-2 rounded shadow"
+            >
+              Table {m} requested to close the bill.
+            </div>
+          ))}
+        </div>
+      )}
       <div className="ml-40">
       <header className="bg-[#5d3d29] text-[#fff4e4] py-6">
         <div className="container mx-auto px-4 flex justify-between items-center">

--- a/src/pages/Mesa.js
+++ b/src/pages/Mesa.js
@@ -283,6 +283,20 @@ const Mesa = () => {
       setMesa(null);
       localStorage.removeItem("pedidosMesa");
       localStorage.removeItem("mesaAtual");
+      try {
+        const list = JSON.parse(
+          localStorage.getItem("checkoutRequests") || "[]",
+        );
+        if (!list.includes(String(mesa))) {
+          list.push(String(mesa));
+          localStorage.setItem("checkoutRequests", JSON.stringify(list));
+        }
+      } catch {
+        localStorage.setItem(
+          "checkoutRequests",
+          JSON.stringify([String(mesa)]),
+        );
+      }
       setShowOrders(false);
       setShowConfirmation(false);
       setShowSuccess(true);


### PR DESCRIPTION
## Summary
- highlight tables requesting checkout
- display active checkout alerts on the dashboard
- store checkout requests in `localStorage` when closing a bill

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6850021adea48327b074dade9a4dcf51