### PR TITLE
Add checkout request alerts to Dashboard

### DIFF
--- a/src/dashboard/components/MesasMenu.js
+++ b/src/dashboard/components/MesasMenu.js
@@ -15,6 +15,7 @@ export default function MesasMenu() {
     }
   });
   const [openTable, setOpenTable] = useState(null);
+  const [freedTable, setFreedTable] = useState(null);
 
   useEffect(() => {
     const fetchMesas = () => {
@@ -63,16 +64,24 @@ export default function MesasMenu() {
       console.error("Erro ao liberar mesa", err);
     }
     setMesasOcupadas((prev) => prev.filter((m) => m !== String(mesa)));
-    setOpenTable(null);
     setCheckoutRequests((prev) => {
       const updated = prev.filter((m) => m !== String(mesa));
-      localStorage.setItem("checkoutRequests", JSON.stringify(updated));
+      const value = JSON.stringify(updated);
+      localStorage.setItem("checkoutRequests", value);
+      window.dispatchEvent(
+        new StorageEvent("storage", { key: "checkoutRequests", newValue: value })
+      );
       return updated;
     });
+    setFreedTable(mesa);
+    setTimeout(() => {
+      setFreedTable(null);
+      setOpenTable(null);
+    }, 1500);
   };
 
   return (
-    <aside className="fixed top-0 left-0 h-full w-40 bg-[#5d3d29] text-[#fff4e4] p-4 space-y-2 overflow-y-auto z-40">
+    <aside className="fixed top-0 left-0 h-full w-48 bg-[#5d3d29] text-[#fff4e4] p-4 space-y-2 overflow-y-auto z-40">
       <h2 className="text-lg font-bold mb-4">Mesas</h2>
       {tables.map((t) => {
         const isOccupied = mesasOcupadas.includes(String(t));
@@ -93,7 +102,7 @@ export default function MesasMenu() {
               Mesa {t}
             </button>
             {isOpen && (
-              <div className="absolute left-full top-0 ml-2 bg-white text-[#5d3d29] rounded shadow p-2 space-y-2 z-50">
+              <div className="absolute left-full top-0 ml-2 w-56 bg-white text-[#5d3d29] rounded shadow p-2 space-y-2 z-50">
                 <a
                   href={`/#/mesa?mesa=${t}`}
                   target="_blank"
@@ -104,9 +113,11 @@ export default function MesasMenu() {
                 </a>
                 <button
                   onClick={() => freeTable(t)}
-                  className="w-full bg-green-500 text-white px-2 py-1 rounded"
+                  className={`w-full px-2 py-1 rounded ${
+                    freedTable === t ? "bg-green-600 text-white" : "bg-green-500 text-white"
+                  }`}
                 >
-                  ✔ Liberar Mesa
+                  {freedTable === t ? "✔ Mesa Liberada" : "✔ Liberar Mesa"}
                 </button>
               </div>
             )}

--- a/src/dashboard/components/MesasMenu.js
+++ b/src/dashboard/components/MesasMenu.js
@@ -7,6 +7,13 @@ const tables = Array.from({ length: 15 }, (_, i) => i + 1);
 
 export default function MesasMenu() {
   const [mesasOcupadas, setMesasOcupadas] = useState([]);
+  const [checkoutRequests, setCheckoutRequests] = useState(() => {
+    try {
+      return JSON.parse(localStorage.getItem("checkoutRequests") || "[]");
+    } catch {
+      return [];
+    }
+  });
 
   useEffect(() => {
     const fetchMesas = () => {
@@ -30,11 +37,26 @@ export default function MesasMenu() {
     return () => clearInterval(id);
   }, []);
 
+  useEffect(() => {
+    const handleStorage = (e) => {
+      if (e.key === "checkoutRequests") {
+        try {
+          setCheckoutRequests(JSON.parse(e.newValue || "[]"));
+        } catch {
+          setCheckoutRequests([]);
+        }
+      }
+    };
+    window.addEventListener("storage", handleStorage);
+    return () => window.removeEventListener("storage", handleStorage);
+  }, []);
+
   return (
     <aside className="fixed top-0 left-0 h-full w-40 bg-[#5d3d29] text-[#fff4e4] p-4 space-y-2 overflow-y-auto z-40">
       <h2 className="text-lg font-bold mb-4">Mesas</h2>
       {tables.map((t) => {
         const isOccupied = mesasOcupadas.includes(String(t));
+        const isCheckout = checkoutRequests.includes(String(t));
         return (
           <a
             key={t}
@@ -42,7 +64,11 @@ export default function MesasMenu() {
             target="_blank"
             rel="noopener noreferrer"
             className={`block rounded px-2 py-1 text-center ${
-              isOccupied ? "bg-yellow-300 text-[#5d3d29]" : "bg-[#fff4e4] text-[#5d3d29]"
+              isCheckout
+                ? "bg-red-100 border-2 border-red-500 text-[#5d3d29]"
+                : isOccupied
+                ? "bg-yellow-300 text-[#5d3d29]"
+                : "bg-[#fff4e4] text-[#5d3d29]"
             }`}
           >
             Mesa {t}

--- a/src/dashboard/components/MesasMenu.js
+++ b/src/dashboard/components/MesasMenu.js
@@ -14,6 +14,7 @@ export default function MesasMenu() {
       return [];
     }
   });
+  const [openTable, setOpenTable] = useState(null);
 
   useEffect(() => {
     const fetchMesas = () => {
@@ -51,28 +52,65 @@ export default function MesasMenu() {
     return () => window.removeEventListener("storage", handleStorage);
   }, []);
 
+  const freeTable = async (mesa) => {
+    try {
+      await fetch("/api/limpaMesa", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ mesa: String(mesa) }),
+      });
+    } catch (err) {
+      console.error("Erro ao liberar mesa", err);
+    }
+    setMesasOcupadas((prev) => prev.filter((m) => m !== String(mesa)));
+    setOpenTable(null);
+    setCheckoutRequests((prev) => {
+      const updated = prev.filter((m) => m !== String(mesa));
+      localStorage.setItem("checkoutRequests", JSON.stringify(updated));
+      return updated;
+    });
+  };
+
   return (
     <aside className="fixed top-0 left-0 h-full w-40 bg-[#5d3d29] text-[#fff4e4] p-4 space-y-2 overflow-y-auto z-40">
       <h2 className="text-lg font-bold mb-4">Mesas</h2>
       {tables.map((t) => {
         const isOccupied = mesasOcupadas.includes(String(t));
         const isCheckout = checkoutRequests.includes(String(t));
+        const isOpen = openTable === t;
         return (
-          <a
-            key={t}
-            href={`/#/mesa?mesa=${t}`}
-            target="_blank"
-            rel="noopener noreferrer"
-            className={`block rounded px-2 py-1 text-center ${
-              isCheckout
-                ? "bg-red-100 border-2 border-red-500 text-[#5d3d29]"
-                : isOccupied
-                ? "bg-yellow-300 text-[#5d3d29]"
-                : "bg-[#fff4e4] text-[#5d3d29]"
-            }`}
-          >
-            Mesa {t}
-          </a>
+          <div key={t} className="relative">
+            <button
+              onClick={() => setOpenTable((prev) => (prev === t ? null : t))}
+              className={`w-full rounded px-2 py-1 text-center focus:outline-none ${
+                isCheckout
+                  ? "bg-red-100 border-2 border-red-500 text-[#5d3d29]"
+                  : isOccupied
+                  ? "bg-yellow-300 text-[#5d3d29]"
+                  : "bg-[#fff4e4] text-[#5d3d29]"
+              }`}
+            >
+              Mesa {t}
+            </button>
+            {isOpen && (
+              <div className="absolute left-full top-0 ml-2 bg-white text-[#5d3d29] rounded shadow p-2 space-y-2 z-50">
+                <a
+                  href={`/#/mesa?mesa=${t}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="block bg-[#5d3d29] text-[#fff4e4] px-2 py-1 rounded text-center"
+                >
+                  Acessar Mesa
+                </a>
+                <button
+                  onClick={() => freeTable(t)}
+                  className="w-full bg-green-500 text-white px-2 py-1 rounded"
+                >
+                  ✔ Liberar Mesa
+                </button>
+              </div>
+            )}
+          </div>
         );
       })}
     </aside>

--- a/src/dashboard/components/MesasMenu.js
+++ b/src/dashboard/components/MesasMenu.js
@@ -81,7 +81,7 @@ export default function MesasMenu() {
   };
 
   return (
-    <aside className="fixed top-0 left-0 h-full w-48 bg-[#5d3d29] text-[#fff4e4] p-4 space-y-2 overflow-y-auto z-40">
+    <aside className="fixed top-0 left-0 h-full w-48 md:w-60 bg-[#5d3d29] text-[#fff4e4] p-4 space-y-2 overflow-y-auto z-40">
       <h2 className="text-lg font-bold mb-4">Mesas</h2>
       {tables.map((t) => {
         const isOccupied = mesasOcupadas.includes(String(t));
@@ -91,18 +91,18 @@ export default function MesasMenu() {
           <div key={t} className="relative">
             <button
               onClick={() => setOpenTable((prev) => (prev === t ? null : t))}
-              className={`w-full rounded px-2 py-1 text-center focus:outline-none ${
+              className={`w-full rounded px-2 py-2 text-center focus:outline-none ${
                 isCheckout
                   ? "bg-red-100 border-2 border-red-500 text-[#5d3d29]"
                   : isOccupied
-                  ? "bg-yellow-300 text-[#5d3d29]"
-                  : "bg-[#fff4e4] text-[#5d3d29]"
+                    ? "bg-yellow-300 text-[#5d3d29]"
+                    : "bg-[#fff4e4] text-[#5d3d29]"
               }`}
             >
               Mesa {t}
             </button>
             {isOpen && (
-              <div className="absolute left-full top-0 ml-2 w-56 bg-white text-[#5d3d29] rounded shadow p-2 space-y-2 z-50">
+              <div className="absolute md:left-full md:top-0 md:ml-2 left-0 top-full mt-2 w-48 sm:w-56 md:w-60 bg-white text-[#5d3d29] rounded shadow p-2 space-y-2 z-50">
                 <a
                   href={`/#/mesa?mesa=${t}`}
                   target="_blank"

--- a/src/pages/Dashboard.js
+++ b/src/pages/Dashboard.js
@@ -24,12 +24,33 @@ const Dashboard = () => {
   const [autorizado, setAutorizado] = useState(false);
   const [orders, setOrders] = useState([]);
   const [filter, setFilter] = useState("today");
+  const [checkoutRequests, setCheckoutRequests] = useState(() => {
+    try {
+      return JSON.parse(localStorage.getItem("checkoutRequests") || "[]");
+    } catch {
+      return [];
+    }
+  });
 
   useEffect(() => {
     fetch(API_URL)
       .then((res) => res.json())
       .then((data) => setOrders(data))
       .catch((err) => console.error("Falha ao buscar API", err));
+  }, []);
+
+  useEffect(() => {
+    const handleStorage = (e) => {
+      if (e.key === "checkoutRequests") {
+        try {
+          setCheckoutRequests(JSON.parse(e.newValue || "[]"));
+        } catch {
+          setCheckoutRequests([]);
+        }
+      }
+    };
+    window.addEventListener("storage", handleStorage);
+    return () => window.removeEventListener("storage", handleStorage);
   }, []);
 
   useEffect(() => {
@@ -161,6 +182,13 @@ const Dashboard = () => {
   return (
     <div className="min-h-screen bg-[#fff4e4]">
       <MesasMenu />
+      {checkoutRequests.length > 0 && (
+        <div className="fixed top-0 right-0 m-4 w-64 bg-red-100 border border-red-500 text-[#5d3d29] p-4 space-y-2 z-50">
+          {checkoutRequests.map((m) => (
+            <p key={m}>Mesa {m} solicitou fechar a conta.</p>
+          ))}
+        </div>
+      )}
       <div className="ml-40">
       <header className="bg-[#5d3d29] text-[#fff4e4] py-6">
         <div className="container mx-auto px-4 flex justify-between items-center">

--- a/src/pages/Dashboard.js
+++ b/src/pages/Dashboard.js
@@ -189,7 +189,7 @@ const Dashboard = () => {
           ))}
         </div>
       )}
-      <div className="ml-40">
+      <div className="ml-48">
       <header className="bg-[#5d3d29] text-[#fff4e4] py-6">
         <div className="container mx-auto px-4 flex justify-between items-center">
           <h1 className="text-2xl font-bold">Painel</h1>

--- a/src/pages/Dashboard.js
+++ b/src/pages/Dashboard.js
@@ -189,7 +189,7 @@ const Dashboard = () => {
           ))}
         </div>
       )}
-      <div className="ml-48">
+      <div className="ml-48 md:ml-60">
       <header className="bg-[#5d3d29] text-[#fff4e4] py-6">
         <div className="container mx-auto px-4 flex justify-between items-center">
           <h1 className="text-2xl font-bold">Painel</h1>

--- a/src/pages/Mesa.js
+++ b/src/pages/Mesa.js
@@ -278,6 +278,19 @@ const Mesa = () => {
         body: JSON.stringify({ mesa: String(mesa).trim() }),
       });
 
+      try {
+        const stored = JSON.parse(localStorage.getItem("checkoutRequests") || "[]");
+        if (!stored.includes(String(mesa))) {
+          const updated = [...stored, String(mesa)];
+          localStorage.setItem("checkoutRequests", JSON.stringify(updated));
+        } else {
+          // trigger storage event
+          localStorage.setItem("checkoutRequests", JSON.stringify(stored));
+        }
+      } catch {
+        localStorage.setItem("checkoutRequests", JSON.stringify([String(mesa)]));
+      }
+
       setPedidosMesa([]);
       setCart([]);
       setMesa(null);


### PR DESCRIPTION
## Summary
- track checkout requests in localStorage from `Mesa`
- listen for checkout requests in `Dashboard` and `MesasMenu`
- highlight tables requesting checkout in red
- show alert sidebar listing pending checkout requests

## Testing
- `npm install --silent`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68500609a34c832784ce4588a9c23c7b