### PR TITLE
Show multiple checkout notifications with individual dismiss

### DIFF
--- a/src/pages/Dashboard.js
+++ b/src/pages/Dashboard.js
@@ -32,7 +32,16 @@ const Dashboard = () => {
     }
   });
 
-  const clearCheckoutRequest = (mesa) => {
+  const clearCheckoutRequest = async (mesa) => {
+    try {
+      await fetch("/api/limpaMesa", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ mesa: String(mesa) }),
+      });
+    } catch (err) {
+      console.error("Erro ao liberar mesa", err);
+    }
     setCheckoutRequests((prev) => {
       const updated = prev.filter((m) => m !== mesa);
       const value = JSON.stringify(updated);
@@ -203,7 +212,7 @@ const Dashboard = () => {
                 onClick={() => clearCheckoutRequest(m)}
                 className="text-sm text-red-700 hover:underline"
               >
-                Ok
+                ✔ Atendido – Liberar Mesa
               </button>
             </div>
           ))}


### PR DESCRIPTION
## Summary
- allow freeing the table when clicking checkout alert button
- show button text `✔ Atendido – Liberar Mesa`

## Testing
- `npm test --silent --maxWorkers=2`

------
https://chatgpt.com/codex/tasks/task_e_6851d4ec2e348327a4151edba3e237a3