### PR TITLE
Fix fechar conta API call

### DIFF
--- a/src/pages/Mesa.js
+++ b/src/pages/Mesa.js
@@ -10,7 +10,7 @@ import {
 import { toast, ToastContainer } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
 import PriceButtons, { parsePrices } from "../components/PriceButtons";
-import { moverParaFecharConta } from "../utils/gsActions";
+import { fecharContaMesa } from "../utils/gsActions";
 
 const Mesa = () => {
   const location = useLocation();
@@ -274,7 +274,7 @@ const Mesa = () => {
       }
       // Atualiza status da mesa via API
       try {
-        await moverParaFecharConta(String(mesa));
+        await fecharContaMesa(String(mesa));
         toast.success("Conta enviada para fechamento!", {
           position: "bottom-right",
           autoClose: 2000,

--- a/src/utils/gsActions.js
+++ b/src/utils/gsActions.js
@@ -1,4 +1,6 @@
 const API_URL = '/api/gs-router';
+const SCRIPT_URL =
+  'https://script.google.com/macros/s/AKfycbw3q0WCN1EO2A6bS5no9-71AutpAOLpS6L1yNFxetwGcNxdd-Fx92vPZpzRxKwSCT1g/exec';
 
 async function callGs(payload) {
   const response = await fetch(API_URL, {
@@ -20,16 +22,35 @@ async function callGs(payload) {
   }
 }
 
+export async function fecharContaMesa(mesa) {
+  const payload = { acao: 'moverParaFecharConta', mesa: String(mesa) };
+
+  try {
+    const response = await fetch(SCRIPT_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+
+    const data = await response.json();
+
+    if (!response.ok || data.success !== true) {
+      throw new Error(data.message || `Erro ${response.status}`);
+    }
+
+    return data;
+  } catch (err) {
+    console.error('Erro ao fechar conta:', err);
+    throw err;
+  }
+}
+
 export async function enviarPedido(data) {
   return callGs({ acao: 'salvarPedido', ...data });
 }
 
 export async function salvarPedidoMesa(data) {
   return callGs({ acao: 'salvarPedidoMesa', ...data });
-}
-
-export async function fecharContaMesa(mesa) {
-  return callGs({ acao: 'fecharConta', mesa });
 }
 
 export async function moverParaFecharConta(mesa) {


### PR DESCRIPTION
## Summary
- add direct helper to close a table using the Apps Script URL
- call this helper from Mesa page

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68535fbc9e8c832796435973089eeb61