### PR TITLE
Atualiza liberação de mesa

### DIFF
--- a/src/dashboard/Orders.js
+++ b/src/dashboard/Orders.js
@@ -68,6 +68,16 @@ export default function OrdersList() {
     return () => clearInterval(id);
   }, []);
 
+  useEffect(() => {
+    const handleStorage = (e) => {
+      if (e.key === "refreshData") {
+        fetchOrders();
+      }
+    };
+    window.addEventListener("storage", handleStorage);
+    return () => window.removeEventListener("storage", handleStorage);
+  }, []);
+
   // Detect new orders and mark them as unseen
   useEffect(() => {
     const prev = prevOrdersRef.current;

--- a/src/pages/Dashboard.js
+++ b/src/pages/Dashboard.js
@@ -64,8 +64,9 @@ const Dashboard = () => {
     setFreeError(null);
     try {
       const resp = await liberarMesa(String(mesa));
-      if (!resp || resp.success !== true) {
-        throw new Error('Falha na liberacao');
+      const ok = resp && (resp.success === true || resp.success === "true");
+      if (!ok) {
+        throw new Error("Falha na liberacao");
       }
       setCheckoutRequests((prev) => {
         const updated = prev.filter((m) => m !== mesa);
@@ -76,6 +77,15 @@ const Dashboard = () => {
         );
         return updated;
       });
+
+      setTimeout(() => {
+        fetchFecharContaPedidos();
+        const val = String(Date.now());
+        localStorage.setItem("refreshData", val);
+        window.dispatchEvent(
+          new StorageEvent("storage", { key: "refreshData", newValue: val })
+        );
+      }, 1000);
     } catch (err) {
       console.error("Erro ao liberar mesa", err);
       setFreeError(err);


### PR DESCRIPTION
## Summary
- allow success true or string for liberar mesa
- trigger data refresh events after mesa liberated
- re-fetch orders and mesas on refresh events

## Testing
- `npm install`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68538edfb6a48327857bd22dc1d1e789