### PR TITLE
Fix product names when closing table

### DIFF
--- a/src/pages/Mesa.js
+++ b/src/pages/Mesa.js
@@ -251,7 +251,11 @@ const Mesa = () => {
   };
 
   const confirmarFechamento = async () => {
-    const { items: produtos, total } = resumoPedidos;
+    const { items, total } = resumoPedidos;
+
+    const produtos = items
+      .map((it) => `${it.name} x${it.quantity}`)
+      .join(" | ");
 
     const payload = {
       mesa,


### PR DESCRIPTION
## Summary
- fix order finalization so product names are sent as a string

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854094324f4832790c27313fd4b1e8c