### PR TITLE
Show item size in WhatsApp order message

### DIFF
--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -196,7 +196,8 @@ const Home = () => {
     if (marmitasInCart.length > 0) {
       message += "*Marmitas:*\n";
       marmitasInCart.forEach((item) => {
-        message += `• ${item.name} (${item.quantity}x) - R$ ${(
+        const tamanho = item.size ? ` ${item.size}` : "";
+        message += `• ${item.name}${tamanho} (${item.quantity}x) - R$ ${(
           item.price * item.quantity
         ).toFixed(2)}`;
         if (item.observations && item.observations.trim()) {


### PR DESCRIPTION
## Summary
- include selected size when building WhatsApp message

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685d78327aa883278ab090b823dc9a56