### PR TITLE
Handle fechar conta

### DIFF
--- a/api/fechar-conta.js
+++ b/api/fechar-conta.js
@@ -6,12 +6,15 @@ export default async function handler(req, res) {
   try {
     const mesa = String(req.body?.mesa || "").trim();
 
-    const url = "https://script.google.com/macros/s/AKfycbzjc-rRauOqdbVARiH_Ft1P75-iHjBtDChXQIO1Uz4UZ-hYaBNj1UaagMPtC4MN2w/exec";
+    const url =
+      "https://script.google.com/macros/s/AKfycbyqxikwY94QYctHheT0-tE36fM_Wd2YUZ4ZJDB-r5Uem5fhwF_mFvpI8qGNJzRMqwnN/exec";
+
+    const payload = { acao: "fecharConta", mesa };
 
     const response = await fetch(url, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ mesa }),
+      body: JSON.stringify(payload),
     });
 
     const text = await response.text();

--- a/api/webhook-fechar-conta.js
+++ b/api/webhook-fechar-conta.js
@@ -1,0 +1,25 @@
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method Not Allowed' });
+  }
+
+  try {
+    const url = 'http://145.223.31.139:5678/webhook/fecharConta';
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(req.body),
+    });
+
+    const text = await response.text();
+
+    if (!response.ok) {
+      return res.status(500).send(text);
+    }
+
+    res.status(200).send(text);
+  } catch (error) {
+    console.error('Erro ao enviar dados ao webhook:', error);
+    res.status(500).json({ error: 'Erro interno ao chamar webhook', details: error.message });
+  }
+}

--- a/gs/fecharConta.gs
+++ b/gs/fecharConta.gs
@@ -1,0 +1,57 @@
+function doPost(e) {
+  const data = JSON.parse(e.postData.contents);
+  if (data.acao === 'fecharConta') {
+    return fecharConta(data.mesa);
+  }
+  return ContentService.createTextOutput('Ação não suportada');
+}
+
+function fecharConta(mesa) {
+  const ss = SpreadsheetApp.getActiveSpreadsheet();
+  const sheetMesas = ss.getSheetByName('Mesas');
+  const sheetFechar = ss.getSheetByName('fecharConta');
+
+  const values = sheetMesas.getDataRange().getValues();
+  const headers = values.shift();
+  const mesaIdx = headers.indexOf('mesa');
+  if (mesaIdx === -1) return ContentService.createTextOutput('Coluna mesa não encontrada');
+
+  const targetRows = [];
+  const rowNumbers = [];
+  values.forEach((row, idx) => {
+    if (String(row[mesaIdx]).trim() === String(mesa)) {
+      targetRows.push(row);
+      rowNumbers.push(idx + 2); // +2 because values array removed header and is 0-indexed
+    }
+  });
+
+  if (targetRows.length === 0) {
+    return ContentService.createTextOutput('Nenhum pedido para consolidar');
+  }
+
+  const consolidated = headers.map((_, colIdx) => {
+    const columnValues = targetRows.map(r => String(r[colIdx]).trim()).filter(Boolean);
+    const unique = Array.from(new Set(columnValues));
+    if (unique.length === 0) return '';
+    if (unique.length === 1) return unique[0];
+    return unique.join(' | ');
+  });
+
+  // valor de mesa deve ser único
+  consolidated[mesaIdx] = String(mesa);
+
+  // Atualiza status das linhas originais para "fechar conta"
+  const statusIdx = headers.indexOf('status');
+  if (statusIdx !== -1) {
+    rowNumbers.forEach(rn => {
+      sheetMesas.getRange(rn, statusIdx + 1).setValue('fechar conta');
+    });
+    const statusValues = targetRows.map(r => String(r[statusIdx]).trim());
+    const uniqueStatus = Array.from(new Set(statusValues));
+    consolidated[statusIdx] = uniqueStatus.length === 1 ? uniqueStatus[0] : uniqueStatus.join(' | ');
+  }
+
+  sheetFechar.appendRow(consolidated);
+
+  return ContentService.createTextOutput('Conta consolidada');
+}

--- a/src/pages/Mesa.js
+++ b/src/pages/Mesa.js
@@ -302,6 +302,16 @@ const Mesa = () => {
       }
 
       try {
+        await fetch("/api/fechar-conta", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ mesa: String(mesa) }),
+        });
+      } catch (err) {
+        console.error("Erro ao consolidar pedidos:", err);
+      }
+
+      try {
         const stored = JSON.parse(localStorage.getItem("checkoutRequests") || "[]");
         if (!stored.includes(String(mesa))) {
           const updated = [...stored, String(mesa)];

--- a/src/pages/Mesa.js
+++ b/src/pages/Mesa.js
@@ -312,6 +312,17 @@ const Mesa = () => {
       }
 
       try {
+        const pedidos = JSON.parse(localStorage.getItem("pedidosMesa") || "[]");
+        await fetch("/api/webhook-fechar-conta", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ mesa: String(mesa), pedidos }),
+        });
+      } catch (err) {
+        console.error("Erro ao enviar itens para webhook:", err);
+      }
+
+      try {
         const stored = JSON.parse(localStorage.getItem("checkoutRequests") || "[]");
         if (!stored.includes(String(mesa))) {
           const updated = [...stored, String(mesa)];


### PR DESCRIPTION
## Summary
- update API route to hit new Apps Script endpoint and send action `fecharConta`
- invoke new `/api/fechar-conta` route when confirming account closing

## Testing
- `npm test --silent --yes`

------
https://chatgpt.com/codex/tasks/task_e_68668275d1bc8327b8824efff776c6dd