### PR TITLE
Remove success alert and open WhatsApp immediately

### DIFF
--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -299,25 +299,21 @@ const Home = () => {
         // log de erro mais detalhado
         const text = await response.text();
         console.error("Erro ao enviar pedido:", text);
-        alert("Ocorreu um erro ao enviar o pedido.");
         return false;
       }
 
       // 4. se chegou aqui, foi sucesso
-      alert("Pedido enviado com sucesso!");
       return true;
     } catch (error) {
       console.error("Erro na requisição:", error);
-      alert("Não foi possível enviar o pedido. Tente novamente.");
       return false;
     }
   };
 
-  const finalizarPedido = async () => {
-    const enviado = await enviarPedido();
-    if (enviado) {
-      sendWhatsAppOrder();
-    }
+  const finalizarPedido = () => {
+    sendWhatsAppOrder();
+    // envio registrado em segundo plano; erros serão apenas logados
+    enviarPedido().catch((err) => console.error("Erro ao enviar pedido:", err));
   };
 
   const camposObrigatoriosVazios = () => {


### PR DESCRIPTION
## Summary
- send the WhatsApp message without waiting for backend response
- drop the success popup when sending an order
- log API errors instead of showing an alert

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d3488ff9c8327a0f3991e3ff623e3