### PR TITLE
Adiciona envio de pedidos para webhook

### DIFF
--- a/api/webhook-mesas.js
+++ b/api/webhook-mesas.js
@@ -1,0 +1,25 @@
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method Not Allowed' });
+  }
+
+  try {
+    const url = 'http://93.127.210.229:5678/webhook/mesas';
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(req.body),
+    });
+
+    const text = await response.text();
+
+    if (!response.ok) {
+      return res.status(500).send(text);
+    }
+
+    res.status(200).send(text);
+  } catch (error) {
+    console.error('Erro ao enviar dados ao webhook:', error);
+    res.status(500).json({ error: 'Erro interno ao chamar webhook', details: error.message });
+  }
+}

--- a/src/pages/Mesa.js
+++ b/src/pages/Mesa.js
@@ -249,6 +249,15 @@ const Mesa = () => {
         const text = await response.text();
         console.error("Erro ao registrar pedido:", text);
       }
+      try {
+        await fetch("/api/webhook-mesas", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload),
+        });
+      } catch (err) {
+        console.error("Erro ao enviar dados ao webhook:", err);
+      }
     } catch (err) {
       console.error("Erro na requisição:", err);
     } finally {


### PR DESCRIPTION
## Resumo
- criar api `webhook-mesas.js` para encaminhar pedidos para o webhook externo
- atualizar `Mesa.js` para chamar a nova API ao enviar pedido

## Testes
- `npm test` *(sem testes relacionados)*

------
https://chatgpt.com/codex/tasks/task_e_68867ac42bd8832785ee0f7de7e14ba7